### PR TITLE
Enhance with Architecture Filtering and Multi-Link Support

### DIFF
--- a/Private/Get-UpdateLinks.ps1
+++ b/Private/Get-UpdateLinks.ps1
@@ -36,11 +36,9 @@ function Get-UpdateLinks {
     $KbLinks = foreach ($Match in $DownloadMatches) {
         [PSCustomObject]@{
             URL = $Match.Groups[1].Value
-            KB  = [int]$Match.Groups[2].Value
+            KB  = if ($Match.Groups.Count -gt 2 -and $Match.Groups[2].Success) { [int]$Match.Groups[2].Value } else { 0 }
         }
     }
     
-    $Links = $KbLinks | Sort-Object KB -Descending
-    $Links[0].URL
-	}
-    
+    return $KbLinks | Sort-Object KB -Descending
+}

--- a/Public/Get-MSCatalogUpdate.ps1
+++ b/Public/Get-MSCatalogUpdate.ps1
@@ -17,15 +17,18 @@ function Get-MSCatalogUpdate {
         [switch] $Strict,
 
         [Parameter(Mandatory = $false)]
-        [switch] $GetFramework
+        [switch] $GetFramework,
+        
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("all", "x64", "x86", "arm64")]
+        [string] $Architecture = "all",
+        
+        [Parameter(Mandatory = $false)]
+        [switch] $IncludePreview,
+        
+        [Parameter(Mandatory = $false)]
+        [switch] $IncludeDynamic
     )
-    
-# Default settings for the search
-    
-$Bit64 = $true  # Include only x64 updates
-$ExcludePreview = $true # Exclude Preview updates
-$ExcludeDynamic = $true # Exclude Dynamic updates
-
 
    try {
        $ProgPref = $ProgressPreference
@@ -54,11 +57,11 @@ $ExcludeDynamic = $true # Exclude Dynamic updates
                 }
             } 
 
-        if ($ExcludeDynamic) {
+        if (-not $IncludeDynamic) {
             $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -notlike "*Dynamic*"})  
             }
 
-        if ($ExcludePreview) {
+        if (-not $IncludePreview) {
             $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -notlike "*Preview*"})  
             }
 
@@ -66,9 +69,19 @@ $ExcludeDynamic = $true # Exclude Dynamic updates
             $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -notlike "*Framework*"})  
             }
 
-        if ($Bit64) {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*x64*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*64-Bit*"})  
+        if ($Architecture -ne "all") {
+            switch ($Architecture) {
+                "x64" { 
+                    $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*x64*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*64-Bit*"})
+                }
+                "x86" {
+                    $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*x86*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*32-Bit*"})
+                }
+                "arm64" {
+                    $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*arm64*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*ARM*"})
+                }
             }
+        }
 
         if ($Search -match "Windows 10") {
             $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*Windows 10*"})  
@@ -76,6 +89,10 @@ $ExcludeDynamic = $true # Exclude Dynamic updates
 
         if ($Search -match "Windows 11") {
             $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*Windows 11*"})  
+            }
+
+        if ($Search -match "Windows Server") {
+            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*Windows Server*"})  
             }
 
         if ($GetFramework) {


### PR DESCRIPTION
# Pull Request Description

This PR introduces several enhancements to the PowerShell scripts used for retrieving and processing updates from the Microsoft Update Catalog.

## Get-MSCatalogUpdate.ps1

### Added new parameters:
- **`-Architecture`**: Allows filtering updates by architecture (`all`, `x64`, `x86`, `arm64`).
- **`-IncludePreview`**: Includes or excludes preview updates.
- **`-IncludeDynamic`**: Includes or excludes dynamic updates.

### Implemented filtering logic:
- Filters results based on the specified architecture.
- Filters updates related to Windows Server.
- Excludes dynamic updates and preview updates based on provided parameters.

## Save-MSCatalogUpdate.ps1 & Get-UpdateLinks.ps1

### Enhanced download link handling:
- Modified logic to support multiple download links associated with a single update.

These improvements enhance flexibility and provide more precise filtering of retrieved updates.
