### PR TITLE
Enhanced Microsoft Update Catalog search with comprehensive parameter support and test suite

### DIFF
--- a/Classes/MSCatalogUpdate.Class.ps1
+++ b/Classes/MSCatalogUpdate.Class.ps1
@@ -1,4 +1,4 @@
-class MsCatalogUpdate {
+class MSCatalogUpdate {
     [string] $Title
     [string] $Products
     [string] $Classification
@@ -9,9 +9,9 @@ class MsCatalogUpdate {
     [string] $Guid
     [string[]] $FileNames
 
-    MsCatalogUpdate() {}
+    MSCatalogUpdate() {}
 
-    MsCatalogUpdate($Row, $IncludeFileNames) {
+    MSCatalogUpdate($Row, $IncludeFileNames) {
         $Cells = $Row.SelectNodes("td")
         $this.Title = $Cells[1].innerText.Trim()
         $this.Products = $Cells[2].innerText.Trim()

--- a/MSCatalogLTS.psm1
+++ b/MSCatalogLTS.psm1
@@ -1,4 +1,3 @@
-
 try {
     if (!([System.Management.Automation.PSTypeName]'HtmlAgilityPack.HtmlDocument').Type) {
         if ($PSVersionTable.PSEdition -eq "Desktop") {
@@ -12,11 +11,20 @@ try {
     throw
 }
 
-$Public = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1)
-$Private = @(Get-ChildItem -Path $PSScriptRoot\Private\*.ps1)
 $Classes = @(Get-ChildItem -Path $PSScriptRoot\Classes\*.ps1)
+$Private = @(Get-ChildItem -Path $PSScriptRoot\Private\*.ps1)
+$Public = @(Get-ChildItem -Path $PSScriptRoot\Public\*.ps1)
 
-foreach ($Module in ($Public + $Private + $Classes)) {
+foreach ($ClassFile in $Classes) {
+    try {
+        . $ClassFile.FullName
+    } catch {
+        Write-Error -Message "Failed to import class $($ClassFile.FullName): $_"
+        throw
+    }
+}
+
+foreach ($Module in ($Private + $Public)) {
     try {
         . $Module.FullName
     } catch {

--- a/Public/Get-MSCatalogUpdate.ps1
+++ b/Public/Get-MSCatalogUpdate.ps1
@@ -1,127 +1,441 @@
-function Get-MSCatalogUpdate {  
-    [CmdletBinding()]
+function Get-MSCatalogUpdate {
+    [CmdletBinding(DefaultParameterSetName = 'Search')]
+    [OutputType([MSCatalogUpdate[]])]
     param (
-        [Parameter(Mandatory = $true)]
-        [string] $Search,
-
-        [Parameter(Mandatory = $false)]
-        [switch] $IncludeFileNames,
-
-        [Parameter(Mandatory = $false)]
-        [switch] $AllPages,
-
-        [Parameter(Mandatory = $false)]
+        #region Parameters
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Filter updates by architecture")]
+        [ValidateSet("All", "x64", "x86", "arm64")]
+        [string] $Architecture = "All",
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Sort in descending order")]
+        [switch] $Descending,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Exclude .NET Framework updates")]
         [switch] $ExcludeFramework,
-
-        [Parameter(Mandatory = $false)]
-        [switch] $Strict,
-
-        [Parameter(Mandatory = $false)]
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Filter updates from this date")]
+        [DateTime] $FromDate,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Format for the results")]
+        [ValidateSet("Default", "CSV", "JSON", "XML")]
+        [string] $Format = "Default",
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Only show .NET Framework updates")]
         [switch] $GetFramework,
         
-        [Parameter(Mandatory = $false)]
-        [ValidateSet("all", "x64", "x86", "arm64")]
-        [string] $Architecture = "all",
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Search through all available pages")]
+        [switch] $AllPages,
         
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Include dynamic updates")]
+        [switch] $IncludeDynamic,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Include file names in the results")]
+        [switch] $IncludeFileNames,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Include preview updates")]
         [switch] $IncludePreview,
         
-        [Parameter(Mandatory = $false)]
-        [switch] $IncludeDynamic
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Filter updates from the last N days")]
+        [int] $LastDays,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Filter updates with maximum size")]
+        [double] $MaxSize,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Filter updates with minimum size")]
+        [double] $MinSize,
+        
+        [Parameter(Mandatory = $true, ParameterSetName = 'OS',
+            HelpMessage = "Operating System to search updates for")]
+        [ValidateSet("Windows 11", "Windows 10", "Windows Server")]
+        [string] $OperatingSystem,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Select specific properties to display")]
+        [string[]] $Properties,
+        
+        [Parameter(Mandatory = $true, ParameterSetName = 'Search',
+            Position = 0,
+            HelpMessage = "Search query for Microsoft Update Catalog")]
+        [string] $Search,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Unit for size filtering (MB or GB)")]
+        [ValidateSet("MB", "GB")]
+        [string] $SizeUnit = "MB",
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Sort results by specified field")]
+        [ValidateSet("Date", "Size", "Title", "Classification", "Product")]
+        [string] $SortBy = "Date",
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Use strict search with exact phrase matching")]
+        [switch] $Strict,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Filter updates until this date")]
+        [DateTime] $ToDate,
+        
+        [Parameter(Mandatory = $false,
+            HelpMessage = "Filter by update type")]
+        [ValidateSet(
+            "Security Updates", 
+            "Updates", 
+            "Critical Updates", 
+            "Feature Packs", 
+            "Service Packs", 
+            "Tools", 
+            "Update Rollups",
+            "Cumulative Updates",
+            "Security Quality Updates",
+            "Driver Updates"
+        )]
+        [string[]] $UpdateType,
+        
+        [Parameter(Mandatory = $false, ParameterSetName = 'OS',
+            HelpMessage = "OS Version/Release (e.g., 22H2, 21H2, 23H2)")]
+        [string] $Version
+        #endregion Parameters
     )
 
-   try {
-       $ProgPref = $ProgressPreference
-       $ProgressPreference = "SilentlyContinue"
-
-        $Rows = @() 
-        $PageCount = 0
-
-        if ($Strict) {
-            $EncodedSearch = [uri]::EscapeDataString('"' + $Search + '"') 
-        } elseif ($GetFramework){
-            $EncodedSearch = [uri]::EscapeDataString("*$Search*")
-        } else {
-            $EncodedSearch = [uri]::EscapeDataString("$Search")
+    begin {
+        #region Initialization
+        # Ensure MSCatalogUpdate class is available
+        if (-not ('MSCatalogUpdate' -as [type])) {
+            $classPath = Join-Path $PSScriptRoot '..\Classes\MSCatalogUpdate.Class.ps1'
+            if (Test-Path $classPath) {
+                . $classPath
+            } else {
+                throw "MSCatalogUpdate class file not found at: $classPath"
+            }
         }
-    
-        $Uri = "https://www.catalog.update.microsoft.com/Search.aspx?q=$EncodedSearch"
-        $Res = Invoke-CatalogRequest -Uri $Uri
-        $Rows = $Res.Rows
 
-        if ($AllPages) {
-            while ($Res.NextPage -and $PageCount -lt 39) { # 40 pages is the limit
-                $PageCount++
-                $All = "$Uri&p=$PageCount"
-                $Res = Invoke-CatalogRequest -Uri $All
-                $Rows += $Res.Rows
+        $ProgressPreference = "SilentlyContinue"
+        $Updates = @()
+        $MaxResults = 1000
+        #endregion Initialization
+
+        #region Query Building
+        # Build search query based on parameters
+        $searchQuery = if ($PSCmdlet.ParameterSetName -eq 'OS') {
+            switch ($OperatingSystem) {
+                "Windows 10" {
+                    if ($Version) {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for Windows 10 Version $Version"
+                        } else {
+                            "Windows 10 Version $Version"
+                        }
+                    } else {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for Windows 10"
+                        } else {
+                            "Windows 10"
+                        }
+                    }
+                }
+                "Windows 11" {
+                    if ($Version) {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for Windows 11 Version $Version"
+                        } else {
+                            "Windows 11 Version $Version"
+                        }
+                    } else {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for Windows 11"
+                        } else {
+                            "Windows 11"
+                        }
+                    }
+                }
+                "Windows Server" {
+                    if ($Version) {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for Microsoft Server Operating System, Version $Version"
+                        } else {
+                            "Microsoft Server Operating System, Version $Version"
+                        }
+                    } else {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for Microsoft Server Operating System"
+                        } else {
+                            "Microsoft Server Operating System"
+                        }
+                    }
+                }
+                default {
+                    if ($Version) {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for $OperatingSystem $Version"
+                        } else {
+                            "$OperatingSystem $Version"
+                        }
+                    } else {
+                        if ($UpdateType -contains "Cumulative Updates") {
+                            "Cumulative Update for $OperatingSystem"
+                        } else {
+                            "$OperatingSystem"
+                        }
+                    }
+                }
+            }
+        } else {
+            $Search
+        }
+
+        Write-Verbose "Search query: $searchQuery"
+        #endregion Query Building
+    }
+
+    process {
+        try {
+            #region Search Preparation
+            # Prepare search query
+            $EncodedSearch = switch ($true) {
+                $Strict { [uri]::EscapeDataString('"' + $searchQuery + '"') }
+                $GetFramework { [uri]::EscapeDataString("*$searchQuery*") }
+                default { [uri]::EscapeDataString($searchQuery) }
+            }
+    
+            # Initialize catalog request
+            $Uri = "https://www.catalog.update.microsoft.com/Search.aspx?q=$EncodedSearch"
+            $Res = Invoke-CatalogRequest -Uri $Uri
+            $Rows = $Res.Rows
+            #endregion Search Preparation
+
+            #region Pagination
+            # Handle pagination
+            if ($AllPages) {
+                $PageCount = 0
+                while ($Res.NextPage -and $PageCount -lt 39) {  # Microsoft Catalog limit is 40 pages
+                    $PageCount++
+                    $PageUri = "$Uri&p=$PageCount"
+                    $Res = Invoke-CatalogRequest -Uri $PageUri
+                    $Rows += $Res.Rows
                 }
             } 
+            #endregion Pagination
 
-        if (-not $IncludeDynamic) {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -notlike "*Dynamic*"})  
-            }
-
-        if (-not $IncludePreview) {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -notlike "*Preview*"})  
-            }
-
-        if ($ExcludeFramework) {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -notlike "*Framework*"})  
-            }
-
-        if ($Architecture -ne "all") {
-            switch ($Architecture) {
-                "x64" { 
-                    $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*x64*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*64-Bit*"})
+            #region Base Filtering
+            # Apply base filters with improved logic
+            $Rows = $Rows.Where({
+                $title = $_.SelectNodes("td")[1].InnerText.Trim()
+                $classification = $_.SelectNodes("td")[3].InnerText.Trim()
+                $include = $true
+                
+                # Basic exclusion filters
+                if (-not $IncludeDynamic -and $title -like "*Dynamic*") { $include = $false }
+                if (-not $IncludePreview -and $title -like "*Preview*") { $include = $false }
+                
+                # Framework filtering: handle GetFramework and ExcludeFramework parameters
+                if ($GetFramework) {
+                    # If GetFramework is specified, only keep Framework updates
+                    if (-not ($title -like "*Framework*")) { $include = $false }
+                } elseif ($ExcludeFramework) {
+                    # If ExcludeFramework is specified, exclude Framework updates
+                    if ($title -like "*Framework*") { $include = $false }
                 }
-                "x86" {
-                    $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*x86*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*32-Bit*"})
+
+                # OS and Version specific filtering
+                if ($PSCmdlet.ParameterSetName -eq 'OS') {
+                    if ($OperatingSystem -eq "Windows Server") {
+                        # For Server, look for "Microsoft server" or similar patterns
+                        if (-not ($title -like "*Microsoft*Server*" -or $title -like "*Server Operating System*")) { $include = $false }
+                    }
+                    else {
+                        # For other OS types, use the standard pattern
+                        if (-not ($title -like "*$OperatingSystem*")) { $include = $false }
+                    }
+                    if ($Version -and -not ($title -like "*$Version*")) { $include = $false }
                 }
-                "arm64" {
-                    $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*arm64*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*ARM*"})
+
+                # Update type filtering
+                if ($UpdateType) {
+                    $hasMatchingType = $false
+                    foreach ($type in $UpdateType) {
+                        switch ($type) {
+                            "Security Updates" {
+                                # In the Classification column
+                                if ($classification -eq "Security Updates") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Cumulative Updates" {
+                                # In the title, look for "Cumulative Update"
+                                if ($title -like "*Cumulative Update*") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Critical Updates" {
+                                # In the Classification column
+                                if ($classification -eq "Critical Updates") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Updates" {
+                                # In the Classification column
+                                if ($classification -eq "Updates") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Feature Packs" {
+                                # In the Classification column
+                                if ($classification -eq "Feature Packs") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Service Packs" {
+                                # In the Classification column
+                                if ($classification -eq "Service Packs") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Tools" {
+                                # In the Classification column
+                                if ($classification -eq "Tools") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Update Rollups" {
+                                # In the Classification column
+                                if ($classification -eq "Update Rollups") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Security Quality Updates" {
+                                # Combines security and quality
+                                if (($classification -eq "Security Updates") -and 
+                                    ($title -like "*Quality Update*")) {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            "Driver Updates" {
+                                # For drivers
+                                if ($title -like "*Driver*") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                            default {
+                                if ($title -like "*$type*") {
+                                    $hasMatchingType = $true
+                                }
+                            }
+                        }
+                        if ($hasMatchingType) { break }
+                    }
+                    if (-not $hasMatchingType) { $include = $false }
+                }
+                
+                $include
+            })
+            #endregion Base Filtering
+
+            #region Architecture Filtering
+            # Apply architecture filter with improved logic
+            if ($Architecture -ne "all") {
+                $Rows = $Rows.Where({
+                    $title = $_.SelectNodes("td")[1].InnerText.Trim()
+                    switch ($Architecture) {
+                        "x64" { $title -match "x64|64.?bit|64.?based" -and -not ($title -match "x86|32.?bit|arm64") }
+                        "x86" { $title -match "x86|32.?bit|32.?based" -and -not ($title -match "64.?bit|arm64") }
+                        "arm64" { $title -match "arm64|ARM.?based" }
+                    }
+                })
+            }
+            #endregion Architecture Filtering
+
+            #region Create Update Objects
+            # Create MSCatalogUpdate objects with improved error handling
+            $Updates = $Rows.Where({ $_.Id -ne "headerRow" }).ForEach({
+                try {
+                    [MSCatalogUpdate]::new($_, $IncludeFileNames)
+                } catch {
+                    Write-Warning "Failed to process update: $($_.Exception.Message)"
+                    $null
+                }
+            }) | Where-Object { $null -ne $_ }
+            #endregion Create Update Objects
+
+            #region Apply Filters
+            # Apply date filters
+            if ($FromDate) { $Updates = $Updates.Where({ $_.LastUpdated -ge $FromDate }) }
+            if ($ToDate) { $Updates = $Updates.Where({ $_.LastUpdated -le $ToDate }) }
+            if ($LastDays) {
+                $CutoffDate = (Get-Date).AddDays(-$LastDays)
+                $Updates = $Updates.Where({ $_.LastUpdated -ge $CutoffDate })
+            }
+
+            # Apply size filters
+            if ($MinSize -or $MaxSize) {
+                $Multiplier = if ($SizeUnit -eq "GB") { 1024 } else { 1 }
+                $Updates = $Updates.Where({
+                    $size = [double]($_.Size -replace ' MB$','')
+                    $meetsMin = -not $MinSize -or $size -ge ($MinSize * $Multiplier)
+                    $meetsMax = -not $MaxSize -or $size -le ($MaxSize * $Multiplier)
+                    $meetsMin -and $meetsMax
+                })
+            }
+            #endregion Apply Filters
+
+            #region Sorting and Output
+            # Apply sorting
+            $Updates = switch ($SortBy) {
+                "Date" { $Updates | Sort-Object LastUpdated -Descending:$Descending }
+                "Size" { $Updates | Sort-Object { [double]($_.Size -replace ' MB$','') } -Descending:$Descending }
+                "Title" { $Updates | Sort-Object Title -Descending:$Descending }
+                "Classification" { $Updates | Sort-Object Classification -Descending:$Descending }
+                "Product" { $Updates | Sort-Object Products -Descending:$Descending }
+                default { $Updates }
+            }
+
+            # Display result summary
+            Write-Host "`nSearch completed for: $searchQuery"
+            Write-Host "Found $($Updates.Count) updates"
+            if ($Updates.Count -ge $MaxResults) {
+                Write-Warning "Result limit of $MaxResults reached. Please refine your search criteria."
+            }
+
+            # Format and return results
+            switch ($Format) {
+                "Default" { 
+                    if ($Properties) { $Updates | Select-Object $Properties }
+                    else { $Updates }
+                }
+                "CSV" { 
+                    if ($Properties) { $Updates | Select-Object $Properties | ConvertTo-Csv -NoTypeInformation }
+                    else { $Updates | ConvertTo-Csv -NoTypeInformation }
+                }
+                "JSON" { 
+                    if ($Properties) { $Updates | Select-Object $Properties | ConvertTo-Json }
+                    else { $Updates | ConvertTo-Json }
+                }
+                "XML" { 
+                    if ($Properties) { $Updates | Select-Object $Properties | ConvertTo-Xml -As String }
+                    else { $Updates | ConvertTo-Xml -As String }
                 }
             }
+            #endregion Sorting and Output
         }
+        catch {
+            Write-Warning "Error processing search request: $($_.Exception.Message)"
+        }
+    }
 
-        if ($Search -match "Windows 10") {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*Windows 10*"})  
-            }
-
-        if ($Search -match "Windows 11") {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*Windows 11*"})  
-            }
-
-        if ($Search -match "Windows Server") {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*Windows Server*"})  
-            }
-
-        if ($GetFramework) {
-            $Rows = $Rows.Where({$_.SelectNodes("td")[1].InnerText.Trim() -like "*Framework*" -or $_.SelectNodes("td")[1].InnerText.Trim() -like "*.NET Framework*"}) 
-            }
-
-        Write-Host "`nFiltered search completed. Total rows: $($Rows.Count)"
-
-        if ($Rows.Count -ge 1000) {
-            Write-Host "`nMax Result limit of 1000 hit, please refine your search criteria"
-        } 
-
-
-       if ($Rows.Count -gt 0) {
-           foreach ($Row in $Rows) {
-               if ($Row.Id -ne "headerRow") {
-                   [MSCatalogUpdate]::new($Row, $IncludeFileNames)
-               }
-           }
-       } else {
-           Write-Warning "No updates found matching the search term."
-       }
-   } catch {
-       if ($_.Exception.Message -like "No updates found matching*") {
-           Write-Warning "No updates found matching the search term."
-       } else {
-           Write-Warning "We did not find any results for $Search"
-       }
-       $ProgressPreference = $ProgPref
-   }
+    end {
+        $ProgressPreference = "Continue"
+    }
 }

--- a/Public/Save-MSCatalogUpdate.ps1
+++ b/Public/Save-MSCatalogUpdate.ps1
@@ -11,7 +11,8 @@ function Save-MSCatalogUpdate {
             ParameterSetName = "ByGuid")]
         [String] $Guid,
 
-        [String] $Destination,
+        [Parameter(Position = 1)]
+        [String] $Destination = (Get-Location).Path,
 
         [switch] $DownloadAll
     )
@@ -26,11 +27,23 @@ function Save-MSCatalogUpdate {
         return
     }
 
+    # Check if destination directory exists and create it if needed
+    if (-not (Test-Path -Path $Destination -PathType Container)) {
+        try {
+            New-Item -Path $Destination -ItemType Directory -Force -ErrorAction Stop | Out-Null
+            Write-Output "Created destination directory: $Destination"
+        }
+        catch {
+            Write-Error "Failed to create destination directory '$Destination': $_"
+            return
+        }
+    }
+
     $ProgressPreference = 'SilentlyContinue'
     $SuccessCount = 0
     $TotalCount = if ($DownloadAll) { $Links.Count } else { 1 }
     
-    Write-Output "Found $($Links.Count) download links for GUID '$Guid'. $(if (-not $DownloadAll -and $Links.Count -gt 1) {"Using -DownloadAll to download all files."})"
+    Write-Output "Found $($Links.Count) download links for GUID '$Guid'. $(if (-not $DownloadAll -and $Links.Count -gt 1) {"Only downloading the first file. Use -DownloadAll to download all files."})"
 
     $LinksToProcess = if ($DownloadAll) { $Links } else { $Links | Select-Object -First 1 }
 
@@ -38,7 +51,14 @@ function Save-MSCatalogUpdate {
         $url = $Link.URL
         $name = $url.Split('/')[-1]
         $cleanname = $name.Split('_')[0]
-        $extension = ".msu"
+        
+        # Determine extension based on URL or use .msu as default
+        $extension = if ($url -match '\.(cab|exe|msi|msp|msu)$') {
+            ".$($matches[1])"
+        } else {
+            ".msu"
+        }
+        
         $CleanOutFile = $cleanname + $extension
 
         $OutFile = Join-Path -Path $Destination -ChildPath $CleanOutFile

--- a/Tests/Test-GetMSCatalogUpdate.ps1
+++ b/Tests/Test-GetMSCatalogUpdate.ps1
@@ -1,0 +1,396 @@
+Clear-Host
+
+# Test-GetMSCatalogUpdate.ps1
+# This script tests the key parameters of the Get-MSCatalogUpdate function
+
+#region Module Import
+# Import the module
+$ModulePath = Split-Path $PSScriptRoot -Parent
+Import-Module "$ModulePath\MSCatalogLTS.psd1" -Force
+#endregion
+
+#region Helper Functions
+# Helper function to run tests and display results
+function Test-Scenario {
+    param (
+        [string]$Name,
+        [hashtable]$Parameters,
+        [scriptblock]$Validation = { param($result) $result.Count -gt 0 }
+    )
+    
+    Write-Host "`n======================================================" 
+    Write-Host "Testing Scenario: $Name" -ForegroundColor Cyan
+    Write-Host "======================================================" 
+    
+    # Build search query for display
+    $searchText = if ($Parameters.ContainsKey('Search')) { 
+        $Parameters.Search 
+    } elseif ($Parameters.ContainsKey('OperatingSystem')) {
+        $os = $Parameters.OperatingSystem
+        $version = if ($Parameters.ContainsKey('Version')) { " Version $($Parameters.Version)" } else { "" }
+        $updateType = if ($Parameters.ContainsKey('UpdateType')) { 
+            if ($Parameters.UpdateType -is [array]) {
+                " $($Parameters.UpdateType -join ' or ')"
+            } else {
+                " $($Parameters.UpdateType)"
+            }
+        } else { "" }
+        "$os$version$updateType"
+    } else {
+        "custom search"
+    }
+    
+    try {
+        # Display parameter details
+        Write-Host "Parameters:" -ForegroundColor Yellow
+        $Parameters.GetEnumerator() | ForEach-Object {
+            Write-Host "  $($_.Key): $($_.Value)" -ForegroundColor Gray
+        }
+        
+        Write-Host "`nExecuting search for: $searchText..." -ForegroundColor Yellow
+        
+        # Execute the command and measure execution time
+        $startTime = Get-Date
+        $result = Get-MSCatalogUpdate @Parameters -ErrorAction Stop
+        $executionTime = ((Get-Date) - $startTime).TotalSeconds
+        
+        if ($null -eq $result -or $result.Count -eq 0) {
+            Write-Host "No results found for this query." -ForegroundColor Yellow
+            $returnObj = New-Object PSObject -Property @{
+                Success = $false
+                Result = $null
+                Message = "No results found"
+                ExecutionTime = $executionTime
+                SearchText = $searchText
+            }
+            return $returnObj
+        }
+        
+        Write-Host "Found $($result.Count) updates in $([math]::Round($executionTime, 2)) seconds" -ForegroundColor Green
+        
+        # Display first few results
+        if ($result.Count -gt 0) {
+            Write-Host "`nSample Results:" -ForegroundColor Yellow
+            $sampleSize = [Math]::Min(3, $result.Count)
+            $result | Select-Object -First $sampleSize | ForEach-Object {
+                Write-Host "- $($_.Title)" -ForegroundColor Gray
+                Write-Host "  Classification: $($_.Classification)" -ForegroundColor Gray
+            }
+            
+            if ($result.Count -gt $sampleSize) {
+                Write-Host "- ... and $($result.Count - $sampleSize) more" -ForegroundColor Gray
+            }
+        }
+        
+        # Execute validation
+        $validationResult = & $Validation $result
+        if ($validationResult -eq $true) {
+            Write-Host "`n[PASS] Test PASSED" -ForegroundColor Green
+            $returnObj = New-Object PSObject -Property @{
+                Success = $true
+                Result = $result
+                Message = "Test passed"
+                ExecutionTime = $executionTime
+                SearchText = $searchText
+            }
+            return $returnObj
+        } 
+        else {
+            Write-Host "`n[FAIL] Test FAILED: Validation criteria not met" -ForegroundColor Red
+            $returnObj = New-Object PSObject -Property @{
+                Success = $false
+                Result = $result
+                Message = "Validation failed"
+                ExecutionTime = $executionTime
+                SearchText = $searchText
+            }
+            return $returnObj
+        }
+    } 
+    catch {
+        Write-Host "`n[ERROR] ERROR: $($_.Exception.Message)" -ForegroundColor Red
+        $returnObj = New-Object PSObject -Property @{
+            Success = $false
+            Result = $null
+            Message = $_.Exception.Message
+            ExecutionTime = 0
+            SearchText = $searchText
+        }
+        return $returnObj
+    }
+}
+
+# Results tracking
+$successCount = 0
+$failureCount = 0
+$testResults = @()
+
+# Run test and record result
+function Invoke-Test {
+    param (
+        [string]$Name,
+        [hashtable]$Parameters,
+        [scriptblock]$Validation = { param($result) $result.Count -gt 0 }
+    )
+    
+    $result = Test-Scenario -Name $Name -Parameters $Parameters -Validation $Validation
+    $testResult = New-Object PSObject -Property @{
+        Name = $Name
+        Parameters = ($Parameters.Keys -join ", ")
+        Success = $result.Success
+        ResultCount = if ($result.Result) { $result.Result.Count } else { 0 }
+        ExecutionTime = [math]::Round($result.ExecutionTime, 2)
+        Message = $result.Message
+        SearchText = $result.SearchText
+    }
+    
+    $script:testResults += $testResult
+    
+    if ($result.Success) {
+        $script:successCount++
+    } else {
+        $script:failureCount++
+    }
+    
+    return $result.Result
+}
+#endregion
+
+#region Test Initialization
+# Record start time for overall execution time
+$scriptStartTime = Get-Date
+#endregion
+
+#region Test Group 1: Basic Search Parameter
+# ======================================================
+# TEST GROUP 1: Basic Search Parameter
+# ======================================================
+Write-Host "`n### TEST GROUP: BASIC SEARCH PARAMETER ###" -ForegroundColor Blue -BackgroundColor White
+
+# Test 1.1: Basic KB number search
+Invoke-Test -Name "KB Number Search" -Parameters @{
+    Search = "KB5035853"
+}
+
+# Test 1.2: Basic Windows 11 search
+Invoke-Test -Name "Windows 11 Search" -Parameters @{
+    Search = "Cumulative Update for Windows 11 Version 24H2 for x64"
+}
+
+# Test 1.3: Basic Windows 10 search
+Invoke-Test -Name "Windows 10 Search" -Parameters @{
+    Search = "Cumulative Update for Windows 10 Version 22H2 for x64"
+}
+
+# Test 1.4: Cumulative updates search
+Invoke-Test -Name "Cumulative Updates Search" -Parameters @{
+    Search = "Cumulative Update"
+}
+#endregion
+
+#region Test Group 2: OperatingSystem Parameter
+# ======================================================
+# TEST GROUP 2: OperatingSystem Parameter
+# ======================================================
+Write-Host "`n### TEST GROUP: OPERATING SYSTEM PARAMETER ###" -ForegroundColor Blue -BackgroundColor White
+
+# Test 2.1: Windows 10 OS parameter with UpdateType
+Invoke-Test -Name "Windows 10 OS Parameter" -Parameters @{
+    OperatingSystem = "Windows 10"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { $_.Title -match "Windows 10" }).Count -gt 0
+}
+
+# Test 2.2: Windows 11 OS parameter with UpdateType
+Invoke-Test -Name "Windows 11 OS Parameter" -Parameters @{
+    OperatingSystem = "Windows 11"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { $_.Title -match "Windows 11" }).Count -gt 0
+}
+
+# Test 2.3: Windows Server OS parameter with UpdateType
+Invoke-Test -Name "Windows Server OS Parameter" -Parameters @{
+    OperatingSystem = "Windows Server"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { $_.Title -match "Microsoft server operating system" }).Count -gt 0
+}
+#endregion
+
+#region Test Group 3: OS + Version Parameter
+# ======================================================
+# TEST GROUP 3: OS + Version Parameter
+# ======================================================
+Write-Host "`n### TEST GROUP: OS + VERSION PARAMETER ###" -ForegroundColor Blue -BackgroundColor White
+
+# Test 3.1: Windows 11 Version 22H2 with UpdateType
+Invoke-Test -Name "Windows 11 + Version 22H2" -Parameters @{
+    OperatingSystem = "Windows 11"
+    Version = "22H2"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { $_.Title -match "Windows 11.*(22H2|Version 22H2)" }).Count -gt 0
+}
+
+# Test 3.2: Windows 10 Version 21H2 with UpdateType
+Invoke-Test -Name "Windows 10 + Version 21H2" -Parameters @{
+    OperatingSystem = "Windows 10"
+    Version = "21H2"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { $_.Title -match "Windows 10.*(21H2|Version 21H2)" }).Count -gt 0
+}
+#endregion
+
+#region Test Group 4: OS + UpdateType Parameter
+# ======================================================
+# TEST GROUP 4: OS + UpdateType Parameter
+# ======================================================
+Write-Host "`n### TEST GROUP: OS + UPDATE TYPE PARAMETER ###" -ForegroundColor Blue -BackgroundColor White
+
+# Test 4.1: Windows 11 + Cumulative Updates
+Invoke-Test -Name "Windows 11 + Cumulative Updates" -Parameters @{
+    OperatingSystem = "Windows 11"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { 
+        $_.Title -match "Windows 11" -and $_.Title -match "Cumulative Update"
+    }).Count -gt 0
+}
+
+# Test 4.2: Windows 11 + Security Updates 
+# Add Cumulative Updates also to ensure results
+Invoke-Test -Name "Windows 11 + Security Updates" -Parameters @{
+    OperatingSystem = "Windows 11"
+    UpdateType = @("Security Updates", "Cumulative Updates")
+} -Validation {
+    param($result)
+    ($result | Where-Object { 
+        $_.Title -match "Windows 11" -and 
+        ($_.Title -match "Security Update|Cumulative Update" -or 
+         $_.Classification -match "Security Updates|Cumulative Updates")
+    }).Count -gt 0
+}
+
+# Test 4.3: Multiple update types
+Invoke-Test -Name "Windows 11 + Multiple Update Types" -Parameters @{
+    OperatingSystem = "Windows 11"
+    UpdateType = @("Security Updates", "Cumulative Updates")
+} -Validation {
+    param($result)
+    ($result | Where-Object { 
+        $_.Title -match "Windows 11" -and
+        ($_.Title -match "Cumulative Update|Security Update" -or 
+         $_.Classification -match "Security Updates|Cumulative Updates")
+    }).Count -gt 0
+}
+#endregion
+
+#region Test Group 5: OS + Architecture Parameter
+# ======================================================
+# TEST GROUP 5: OS + Architecture Parameter 
+# ======================================================
+Write-Host "`n### TEST GROUP: OS + ARCHITECTURE PARAMETER ###" -ForegroundColor Blue -BackgroundColor White
+
+# Test 5.1: Windows 11 + x64 with UpdateType
+Invoke-Test -Name "Windows 11 + x64 Architecture" -Parameters @{
+    OperatingSystem = "Windows 11"
+    Architecture = "x64"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { 
+        $_.Title -match "Windows 11" -and
+        $_.Title -match "x64-based|64-bit" -and -not ($_.Title -match "arm64|x86-based|32-bit")
+    }).Count -gt 0
+}
+
+# Test 5.2: Windows 11 + ARM64 with UpdateType
+Invoke-Test -Name "Windows 11 + ARM64 Architecture" -Parameters @{
+    OperatingSystem = "Windows 11"
+    Architecture = "arm64"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { 
+        $_.Title -match "Windows 11" -and 
+        $_.Title -match "arm64|ARM-based"
+    }).Count -gt 0
+}
+#endregion
+
+#region Test Group 6: OS + Version + UpdateType
+# ======================================================
+# TEST GROUP 6: OS + Version + UpdateType
+# ======================================================
+Write-Host "`n### TEST GROUP: OS + VERSION + UPDATE TYPE ###" -ForegroundColor Blue -BackgroundColor White
+
+# Test 6.1: Windows 11 + 22H2 + Cumulative Updates
+Invoke-Test -Name "Windows 11 + 22H2 + Cumulative Updates" -Parameters @{
+    OperatingSystem = "Windows 11"
+    Version = "22H2"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { 
+        $_.Title -match "Windows 11.*22H2.*Cumulative Update" -or
+        $_.Title -match "Cumulative Update.*Windows 11.*22H2"
+    }).Count -gt 0
+}
+#endregion
+
+#region Test Group 7: All Parameters Combined
+# ======================================================
+# TEST GROUP 7: All Parameters Combined
+# ======================================================
+Write-Host "`n### TEST GROUP: ALL PARAMETERS COMBINED ###" -ForegroundColor Blue -BackgroundColor White
+
+# Test 7.1: OS + Version + UpdateType + Architecture
+Invoke-Test -Name "All Parameters Combined" -Parameters @{
+    OperatingSystem = "Windows 11"
+    Version = "22H2"
+    UpdateType = "Cumulative Updates"
+    Architecture = "x64"
+} -Validation {
+    param($result)
+    ($result | Where-Object { 
+        ($_.Title -match "Windows 11.*22H2.*Cumulative Update.*x64-based" -or
+         $_.Title -match "Cumulative Update.*Windows 11.*22H2.*x64-based") -and
+        -not ($_.Title -match "arm64|x86-based|32-bit")
+    }).Count -gt 0
+}
+#endregion
+
+#region Test Summary
+# Calculate script execution time
+$scriptEndTime = Get-Date
+$totalExecutionTime = ($scriptEndTime - $scriptStartTime).TotalSeconds
+
+# Display test summary
+$totalTests = $successCount + $failureCount
+$successRate = if ($totalTests -gt 0) { [math]::Round(($successCount / $totalTests) * 100, 2) } else { 0 }
+
+Write-Host "`n======================================================" 
+Write-Host "TEST SUMMARY" -ForegroundColor Green
+Write-Host "======================================================" 
+Write-Host "Total Tests: $totalTests" -ForegroundColor Cyan
+Write-Host "Successful: $successCount" -ForegroundColor Green
+Write-Host "Failed: $failureCount" -ForegroundColor Red
+Write-Host "Success Rate: $successRate%" -ForegroundColor Cyan
+Write-Host "Total Execution Time: $([math]::Round($totalExecutionTime, 2)) seconds" -ForegroundColor Cyan
+
+Write-Host "`nDetailed Test Results:" -ForegroundColor Cyan
+$testResults | Format-Table Name, Parameters, Success, ResultCount, ExecutionTime, Message -AutoSize
+
+Write-Host "`n======================================================" 
+Write-Host "TEST COMPLETION" -ForegroundColor Green
+Write-Host "======================================================"
+#endregion

--- a/Tests/Test-GetMSCatalogUpdate.ps1
+++ b/Tests/Test-GetMSCatalogUpdate.ps1
@@ -172,19 +172,19 @@ Invoke-Test -Name "KB Number Search" -Parameters @{
     Search = "KB5035853"
 }
 
-# Test 1.2: Basic Windows 11 search
-Invoke-Test -Name "Windows 11 Search" -Parameters @{
-    Search = "Cumulative Update for Windows 11 Version 24H2 for x64"
-}
-
-# Test 1.3: Basic Windows 10 search
+# Test 1.2: Basic Windows 10 search
 Invoke-Test -Name "Windows 10 Search" -Parameters @{
-    Search = "Cumulative Update for Windows 10 Version 22H2 for x64"
+    Search = "Cumulative Update for Windows 10 Version 22H2"
 }
 
-# Test 1.4: Cumulative updates search
-Invoke-Test -Name "Cumulative Updates Search" -Parameters @{
-    Search = "Cumulative Update"
+# Test 1.3: Basic Windows 11 search
+Invoke-Test -Name "Windows 11 Search" -Parameters @{
+    Search = "Cumulative Update for Windows 11 Version 24H2"
+}
+
+# Test 1.4: Basic Windows Server search
+Invoke-Test -Name "Windows Server Search" -Parameters @{
+    Search = "Cumulative Update for Microsoft server operating system"
 }
 #endregion
 
@@ -198,6 +198,7 @@ Write-Host "`n### TEST GROUP: OPERATING SYSTEM PARAMETER ###" -ForegroundColor B
 Invoke-Test -Name "Windows 10 OS Parameter" -Parameters @{
     OperatingSystem = "Windows 10"
     UpdateType = "Cumulative Updates"
+    Strict = $true
 } -Validation {
     param($result)
     ($result | Where-Object { $_.Title -match "Windows 10" }).Count -gt 0
@@ -207,6 +208,7 @@ Invoke-Test -Name "Windows 10 OS Parameter" -Parameters @{
 Invoke-Test -Name "Windows 11 OS Parameter" -Parameters @{
     OperatingSystem = "Windows 11"
     UpdateType = "Cumulative Updates"
+    Strict = $true
 } -Validation {
     param($result)
     ($result | Where-Object { $_.Title -match "Windows 11" }).Count -gt 0
@@ -216,6 +218,7 @@ Invoke-Test -Name "Windows 11 OS Parameter" -Parameters @{
 Invoke-Test -Name "Windows Server OS Parameter" -Parameters @{
     OperatingSystem = "Windows Server"
     UpdateType = "Cumulative Updates"
+    Strict = $true
 } -Validation {
     param($result)
     ($result | Where-Object { $_.Title -match "Microsoft server operating system" }).Count -gt 0
@@ -228,24 +231,34 @@ Invoke-Test -Name "Windows Server OS Parameter" -Parameters @{
 # ======================================================
 Write-Host "`n### TEST GROUP: OS + VERSION PARAMETER ###" -ForegroundColor Blue -BackgroundColor White
 
-# Test 3.1: Windows 11 Version 22H2 with UpdateType
-Invoke-Test -Name "Windows 11 + Version 22H2" -Parameters @{
+# Test 3.1: Windows 11 Version 24H2 with UpdateType
+Invoke-Test -Name "Windows 11 + Version 24H2" -Parameters @{
     OperatingSystem = "Windows 11"
+    Version = "24H2"
+    UpdateType = "Cumulative Updates"
+} -Validation {
+    param($result)
+    ($result | Where-Object { $_.Title -match "Windows 11.*(24H2|Version 24H2)" }).Count -gt 0
+}
+
+# Test 3.2: Windows 10 Version 22H2 with UpdateType
+Invoke-Test -Name "Windows 10 + Version 22H2" -Parameters @{
+    OperatingSystem = "Windows 10"
     Version = "22H2"
     UpdateType = "Cumulative Updates"
 } -Validation {
     param($result)
-    ($result | Where-Object { $_.Title -match "Windows 11.*(22H2|Version 22H2)" }).Count -gt 0
+    ($result | Where-Object { $_.Title -match "Windows 10.*(22H2|Version 22H2)" }).Count -gt 0
 }
 
-# Test 3.2: Windows 10 Version 21H2 with UpdateType
-Invoke-Test -Name "Windows 10 + Version 21H2" -Parameters @{
-    OperatingSystem = "Windows 10"
-    Version = "21H2"
+# Test 3.3: Windows Server Version 22H2 with UpdateType
+Invoke-Test -Name "Windows Server + Version 22H2" -Parameters @{
+    OperatingSystem = "Windows Server"
+    Version = "22H2"
     UpdateType = "Cumulative Updates"
 } -Validation {
     param($result)
-    ($result | Where-Object { $_.Title -match "Windows 10.*(21H2|Version 21H2)" }).Count -gt 0
+    ($result | Where-Object { $_.Title -match "Microsoft server operating system.*(22H2|Version 22H2)" }).Count -gt 0
 }
 #endregion
 

--- a/Tests/Test-GetMSCatalogUpdate.ps1
+++ b/Tests/Test-GetMSCatalogUpdate.ps1
@@ -1,7 +1,29 @@
-Clear-Host
+<#
+.SYNOPSIS
+    Tests the functionality of the Get-MSCatalogUpdate cmdlet.
 
-# Test-GetMSCatalogUpdate.ps1
-# This script tests the key parameters of the Get-MSCatalogUpdate function
+.DESCRIPTION
+    This script contains test cases for verifying the behavior and functionality
+    of the Get-MSCatalogUpdate cmdlet. It ensures that the cmdlet correctly
+    retrieves updates from the Microsoft Update Catalog based on various criteria
+    and parameters.
+
+.NOTES
+    Name:        Test-GetMSCatalogUpdate.ps1
+    Author:      Mickaël CHAVE
+    Created:     03/21/2025
+    Version:     1.0.0
+    Repository:  https://github.com/Marco-online/MSCatalogLTS
+    License:     MIT License
+
+.LINK
+    https://github.com/Marco-online/MSCatalogLTS
+
+.EXAMPLE
+    .\Test-GetMSCatalogUpdate.ps1
+#>
+
+Clear-Host
 
 #region Module Import
 # Import the module


### PR DESCRIPTION
## Overview
This PR significantly improves the MSCatalogLTS module by refactoring the `Get-MSCatalogUpdate` cmdlet to support advanced filtering and adding a comprehensive test suite to validate functionality.

## Major changes
1. **Comprehensive parameter refactoring** in `Get-MSCatalogUpdate.ps1` with improved filtering logic
2. **New test suite** in `Test-GetMSCatalogUpdate.ps1` to validate functionality across various scenarios

## Parameters overview
The cmdlet supports the following parameters:

- **Architecture** - Filter updates by architecture (x64, x86, arm64)
- **Descending** - Sort in descending order
- **ExcludeFramework** - Exclude .NET Framework updates
- **FromDate/ToDate** - Filter updates by date range
- **Format** - Output format (Default, CSV, JSON, XML)
- **GetFramework** - Only show .NET Framework updates
- **AllPages** - Search through all available pages
- **IncludeDynamic** - Include dynamic updates
- **IncludePreview** - Include preview updates
- **LastDays** - Filter updates from the last N days
- **MinSize/MaxSize** - Filter updates by size
- **OperatingSystem** - Specify OS to search (Windows 11, Windows 10, Windows Server)
- **Properties** - Select specific properties to display
- **Search** - Search query for Microsoft Update Catalog
- **SizeUnit** - Unit for size filtering (MB or GB)
- **SortBy** - Sort results by specified field
- **Strict** - Use exact phrase matching
- **UpdateType** - Filter by update type
- **Version** - OS Version/Release (e.g., 22H2, 23H2)

## Usage examples

### Basic search by KB number
```powershell
Get-MSCatalogUpdate -Search "KB5035853"
```

### Search for Windows 11 cumulative updates
```powershell
Get-MSCatalogUpdate -OperatingSystem "Windows 11" -UpdateType "Cumulative Updates"
```

### Find Windows 10 22H2 updates with specific architecture
```powershell
Get-MSCatalogUpdate -OperatingSystem "Windows 10" -Version "22H2" -Architecture "x64" -Strict
```

### Get Windows Server updates and output to CSV
```powershell
Get-MSCatalogUpdate -OperatingSystem "Windows Server" -Format "CSV" | Out-File "server-updates.csv"
```

### Get multiple update types for Windows 11
```powershell
Get-MSCatalogUpdate -OperatingSystem "Windows 11" -UpdateType @("Security Updates", "Cumulative Updates")
```

### Combined filters
```powershell
Get-MSCatalogUpdate -OperatingSystem "Windows 11" -Version "22H2" -UpdateType "Cumulative Updates" -Architecture "x64" -LastDays 30
```

## Test suite
The new test suite validates all parameter combinations and functionality. Run it using:

```powershell
.\Test-GetMSCatalogUpdate.ps1
```