### PR TITLE
Use Split-Path to set correct extension for downloaded files (fix for #12)

### DIFF
--- a/Public/Save-MSCatalogUpdate.ps1
+++ b/Public/Save-MSCatalogUpdate.ps1
@@ -38,7 +38,7 @@ function Save-MSCatalogUpdate {
         $url = $Link.URL
         $name = $url.Split('/')[-1]
         $cleanname = $name.Split('_')[0]
-        $extension = ".msu"
+        $extension = Split-Path -Path $name -Extension
         $CleanOutFile = $cleanname + $extension
 
         $OutFile = Join-Path -Path $Destination -ChildPath $CleanOutFile


### PR DESCRIPTION
Set file extension based on URL source.

Uses Split-Path to identify file extension from download URL and set it in the downloaded file.

Resolves #12.