### PR TITLE
Add pipeline support for Save-MSCatalogUpdate and add Get-MSCatalogUpdateLink

### DIFF
--- a/Classes/MSCatalogUpdate.Class.ps1
+++ b/Classes/MSCatalogUpdate.Class.ps1
@@ -22,7 +22,7 @@ class MSCatalogUpdate {
         $this.SizeInBytes = [Int64] $Cells[6].SelectNodes("span")[1].InnerText 
         $this.Guid = $Cells[7].SelectNodes("input")[0].Id
         $this.FileNames = if ($IncludeFileNames) {
-            $Links = Get-UpdateLinks -Guid $Cells[7].SelectNodes("input")[0].Id
+            $Links = Get-MSCatalogUpdateLink -Guid $Cells[7].SelectNodes("input")[0].Id
             foreach ($Link in $Links.Matches) {
                 $Link.Value.Split('/')[-1]
             }

--- a/MSCatalogLTS.psd1
+++ b/MSCatalogLTS.psd1
@@ -70,7 +70,8 @@
     FunctionsToExport = @(
         'Get-MSCatalogUpdate',
         'Save-MSCatalogUpdate',
-        'Save-MSCatalogOutput'
+        'Save-MSCatalogOutput',
+        'Get-MSCatalogUpdateLink'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Public/Get-MSCatalogUpdateLink.ps1
+++ b/Public/Get-MSCatalogUpdateLink.ps1
@@ -1,0 +1,50 @@
+function Get-MSCatalogUpdateLink {
+    [CmdletBinding()]
+    param (
+        [Parameter(
+            Mandatory = $true,
+            Position = 0,
+            ValueFromPipelineByPropertyName = $true
+        )]
+        [String[]] $Guid
+    )
+
+    process {
+        foreach ($GuidItem in $Guid)
+        {
+            $Post = @{size = 0; UpdateID = $GuidItem; UpdateIDInfo = $GuidItem} | ConvertTo-Json -Compress
+            $Body = @{UpdateIDs = "[$Post]"}
+
+            $Params = @{
+                Uri = "https://www.catalog.update.microsoft.com/DownloadDialog.aspx"
+                Body = $Body
+                ContentType = "application/x-www-form-urlencoded"
+                UseBasicParsing = $true
+            }
+
+            $DownloadDialog = Invoke-WebRequest @Params
+            $Links = $DownloadDialog.Content -replace "www.download.windowsupdate", "download.windowsupdate"
+
+            $Regex = "downloadInformation\[0\]\.files\[\d+\]\.url\s*=\s*'([^']*kb(\d+)[^']*)'"
+            $DownloadMatches = [regex]::Matches($Links, $Regex)
+
+            if ($DownloadMatches.Count -eq 0) {
+                $RegexFallback = "downloadInformation\[0\]\.files\[0\]\.url\s*=\s*'([^']*)'"
+                $DownloadMatches = [regex]::Matches($Links, $RegexFallback)
+            }
+
+            if ($DownloadMatches.Count -eq 0) {
+                continue
+            }
+    
+            $KbLinks = foreach ($Match in $DownloadMatches) {
+                [PSCustomObject]@{
+                    URL = $Match.Groups[1].Value
+                    KB  = if ($Match.Groups.Count -gt 2 -and $Match.Groups[2].Success) { [int]$Match.Groups[2].Value } else { 0 }
+                }
+            }
+
+            $KbLinks | Sort-Object KB -Descending
+        }
+    }
+}

--- a/Public/Save-MSCatalogUpdate.ps1
+++ b/Public/Save-MSCatalogUpdate.ps1
@@ -2,90 +2,98 @@ function Save-MSCatalogUpdate {
     param (
         [Parameter(
             Position = 0, 
-            ParameterSetName = "ByObject")]
+            ParameterSetName = "ByObject",
+            ValueFromPipeline = $true)]
         [Object] $Update,
 
         [Parameter(
             Mandatory = $true, 
             Position = 0, 
             ParameterSetName = "ByGuid")]
-        [String] $Guid,
+        [String[]] $Guid,
 
         [Parameter(Position = 1)]
         [String] $Destination = (Get-Location).Path,
 
         [switch] $DownloadAll
     )
-
-    if ($Update) {
-        $Guid = $Update.Guid | Select-Object -First 1
-    }
-
-    $Links = Get-UpdateLinks -Guid $Guid
-    if (-not $Links) {
-        Write-Warning "No valid download links found for GUID '$Guid'."
-        return
-    }
-
-    # Check if destination directory exists and create it if needed
-    if (-not (Test-Path -Path $Destination -PathType Container)) {
-        try {
-            New-Item -Path $Destination -ItemType Directory -Force -ErrorAction Stop | Out-Null
-            Write-Output "Created destination directory: $Destination"
-        }
-        catch {
-            Write-Error "Failed to create destination directory '$Destination': $_"
-            return
+    begin {
+        # Check if destination directory exists and create it if needed
+        if (-not (Test-Path -Path $Destination -PathType Container)) {
+            try {
+                New-Item -Path $Destination -ItemType Directory -Force -ErrorAction Stop | Out-Null
+                Write-Output "Created destination directory: $Destination"
+            }
+            catch {
+                Write-Error "Failed to create destination directory '$Destination': $_" -ErrorAction Stop
+            }
         }
     }
+    process {
+        $GuidsToProcess = if ($PSCmdlet.ParameterSetName -eq "ByObject") {
+            $Update.Guid
+        }
+        else {
+            $Guid
+        }
 
-    $ProgressPreference = 'SilentlyContinue'
-    $SuccessCount = 0
-    $TotalCount = if ($DownloadAll) { $Links.Count } else { 1 }
+        $ProgressPreference = 'SilentlyContinue'
+        foreach ($GuidItem in $GuidsToProcess)
+        {
+            $Links = Get-MSCatalogUpdateLink -Guid $GuidItem
+            if (-not $Links) {
+                Write-Warning "No valid download links found for GUID '$GuidItem'."
+                continue
+            }
+
+            $SuccessCount = 0
+            $TotalCount = if ($DownloadAll) { $Links.Count } else { 1 }
     
-    Write-Output "Found $($Links.Count) download links for GUID '$Guid'. $(if (-not $DownloadAll -and $Links.Count -gt 1) {"Only downloading the first file. Use -DownloadAll to download all files."})"
+            Write-Output "Found $($Links.Count) download links for GUID '$GuidItem'. $(if (-not $DownloadAll -and $Links.Count -gt 1) {"Only downloading the first file. Use -DownloadAll to download all files."})"
 
-    $LinksToProcess = if ($DownloadAll) { $Links } else { $Links | Select-Object -First 1 }
+            $LinksToProcess = if ($DownloadAll) { $Links } else { $Links | Select-Object -First 1 }
 
-    foreach ($Link in $LinksToProcess) {
-        $url = $Link.URL
-        $name = $url.Split('/')[-1]
-        $cleanname = $name.Split('_')[0]
+            foreach ($Link in $LinksToProcess) {
+                $url = $Link.URL
+                $name = $url.Split('/')[-1]
+                $cleanname = $name.Split('_')[0]
         
-        # Determine extension based on URL or use .msu as default
-        $extension = if ($url -match '\.(cab|exe|msi|msp|msu)$') {
-            ".$($matches[1])"
-        } else {
-            ".msu"
-        }
+                # Determine extension based on URL or use .msu as default
+                $extension = if ($url -match '\.(cab|exe|msi|msp|msu)$') {
+                    ".$($matches[1])"
+                } else {
+                    ".msu"
+                }
         
-        $CleanOutFile = $cleanname + $extension
+                $CleanOutFile = $cleanname + $extension
 
-        $OutFile = Join-Path -Path $Destination -ChildPath $CleanOutFile
+                $OutFile = Join-Path -Path $Destination -ChildPath $CleanOutFile
         
-        if (Test-Path -Path $OutFile) {
-            Write-Warning "File already exists: $CleanOutFile. Skipping download."
-            continue
-        }
+                if (Test-Path -Path $OutFile) {
+                    Write-Warning "File already exists: $CleanOutFile. Skipping download."
+                    continue
+                }
 
-        try {
-            Write-Output "Downloading $CleanOutFile..."
-            Set-TempSecurityProtocol
-            Invoke-WebRequest -Uri $url -OutFile $OutFile -ErrorAction Stop
-            Set-TempSecurityProtocol -ResetToDefault
+                try {
+                    Write-Output "Downloading $CleanOutFile..."
+                    Set-TempSecurityProtocol
+                    Invoke-WebRequest -Uri $url -OutFile $OutFile -ErrorAction Stop
+                    Set-TempSecurityProtocol -ResetToDefault
             
-            if (Test-Path -Path $OutFile) {
-                Write-Output "Successfully downloaded file $CleanOutFile to $Destination"
-                $SuccessCount++
+                    if (Test-Path -Path $OutFile) {
+                        Write-Output "Successfully downloaded file $CleanOutFile to $Destination"
+                        $SuccessCount++
+                    }
+                    else {
+                        Write-Warning "Downloading file $CleanOutFile failed."
+                    }
+                }
+                catch {
+                    Write-Warning "Error downloading $CleanOutFile : $_"
+                }
             }
-            else {
-                Write-Warning "Downloading file $CleanOutFile failed."
-            }
-        }
-        catch {
-            Write-Warning "Error downloading $CleanOutFile : $_"
+
+            Write-Output "Download complete: $SuccessCount of $TotalCount files downloaded successfully."
         }
     }
-
-    Write-Output "Download complete: $SuccessCount of $TotalCount files downloaded successfully."
 }


### PR DESCRIPTION
I added pipeline and array input support so users can use a complete pipeline to find and download updates like:
```
Get-MSCatalogUpdate -Search "Cumulative Update for Windows 11 Version 24H2 for x64" -Strict -LastDays 60 |
    sort LastUpdated -Descending |
    select -First 1 |
    Save-MSCatalogUpdate
```
Or skip the pipeline and download a list of updates: `Save-MSCatalogUpdate -Guid $UpdateGuids`
I also made `Get-UpdateLinks` public and renamed it to a more fitting public name: `Get-MSCatalogUpdateLink` so users can get the download links and download through other means (bits) or do their own link selection instead of only being able to pick the first one or all in cases where an update has multiple download files.